### PR TITLE
feat: relative path file generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ bin/protoc-gen-$(NAME): $(NAME)/$(NAME).pb.go $(wildcard *.go)
 .PHONY: test
 test: build
 	@protoc -I . --plugin=protoc-gen-go=$(shell pwd)/bin/protoc-gen-go --go_out="." tests/*.proto
-	@protoc -I . --plugin=protoc-gen-$(NAME)=$(shell pwd)/bin/protoc-gen-$(NAME) --$(NAME)_out=tests tests/*.proto
+	@protoc -I . --plugin=protoc-gen-$(NAME)=$(shell pwd)/bin/protoc-gen-$(NAME) --$(NAME)_out=. tests/*.proto
 	@cat tests/entity.pb.$(NAME).go
 	@cd tests && go test -v .
 

--- a/sanitizer.go
+++ b/sanitizer.go
@@ -114,11 +114,11 @@ func (p *SanitizeModule) generateFile(f pgs.File) {
 	defer p.Pop()
 	p.Debug("File:", f.InputPath())
 
-	name := f.InputPath().BaseName() + ".pb.sanitize.go"
+	name := p.ctx.OutputPath(f).SetExt(".sanitize.go")
 
 	p.Debug("generate:", name)
 
-	p.AddGeneratorTemplateFile(name, p.tpl, f)
+	p.AddGeneratorTemplateFile(name.String(), p.tpl, f)
 }
 
 func (p *SanitizeModule) leadingCommenter(f pgs.File) string {
@@ -171,7 +171,6 @@ func (p *SanitizeModule) initializer(m pgs.Message) string {
 }
 
 func formatSanitizeCalls(varName string, argName string, sanitizeKind string, isRepeated bool, trim bool) string {
-
 	sanitizeCalls := []string{}
 
 	if isRepeated {


### PR DESCRIPTION
update file generation to use `OutputPath` and `SetExt` from 'protoc-gen-star'

https://github.com/lyft/protoc-gen-star/blob/496ad1ac90a4573d8b89f09e6ef5f8e25dd4adb8/testdata/protoc-gen-example/jsonify.go#L54